### PR TITLE
chore: use `logger.warn` if package/repo not found

### DIFF
--- a/lib/modules/datasource/repology/index.ts
+++ b/lib/modules/datasource/repology/index.ts
@@ -177,7 +177,7 @@ export class RepologyDatasource extends Datasource {
       throw err;
     }
 
-    logger.debug(
+    logger.warn(
       { repoName, pkgName },
       'Repository or package not found on Repology',
     );


### PR DESCRIPTION
## Changes

This PR adds a warning to the log file if the Repology datasource is not able to find the package and/or repository. It was a debug message before.

## Context

In case package/repository are not found it needs to visible in the daily work with Renovate as these packages are never updated due to a wrong setup by the user. Usually the logs are set to `info` or even `warn` as you don't wan't to see `debug` messages on a regular basis.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository